### PR TITLE
Allow contextual actions on collections on a state

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import assign from './utils/assign';
 
 const IS_EMBER_1 = Ember.VERSION.split(".").shift() === "1";
 
@@ -45,11 +46,12 @@ export default Ember.Helper.extend({
             };
             return actions;
           }, {}));
-        })
+        }),
+        configurable: IS_EMBER_1 ? true : false
       };
       return collections;
     }, {});
-    return Object.create(this.wrap(current), Ember.assign({}, actions, collections));
+    return Object.create(this.wrap(current), assign({}, actions, collections));
   },
 
   wrap(value) {

--- a/addon/helpers/choice.js
+++ b/addon/helpers/choice.js
@@ -9,15 +9,17 @@ export default MicroState.extend({
     return Type.create(values, options);
   },
 
-  actions: {
-    toggle(choice, option) {
-      return choice.toggle(option);
-    },
-    select(choice, option) {
-      return choice.toggle(option, true);
-    },
-    deselect(choice, option) {
-      return choice.toggle(option, false);
+  each: {
+    options: {
+      toggle(choice, option) {
+        return choice.toggle(option);
+      },
+      select(choice, option) {
+        return choice.toggle(option, true);
+      },
+      deselect(choice, option) {
+        return choice.toggle(option, false);
+      }
     }
   }
 });

--- a/addon/utils/assign.js
+++ b/addon/utils/assign.js
@@ -1,3 +1,5 @@
 import Ember from 'ember';
 
-export default Ember.assign || Ember.merge;
+export default Ember.assign || function(...objects) {
+  return objects.reduce(Ember.merge);
+};

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -39,7 +39,7 @@
   <br/>
   {{#each pets.options as |option|}}
     <label>
-      <input class="spec-choice spec-choice-{{option.value}}" type="checkbox" checked={{option.isSelected}} onclick={{action pets.toggle option}}>
+      <input class="spec-choice spec-choice-{{option.value}}" type="checkbox" checked={{option.isSelected}} onclick={{action option.toggle}}>
       {{option.value}}
     </label>
   {{/each}}
@@ -47,7 +47,7 @@
   <h3> Multiple Choice </h3>
   {{#each livestock.options as |option|}}
     <label>
-      <input class="spec-multiple-choice spec-multiple-choice-{{option.value}}" type="checkbox" checked={{option.isSelected}} onclick={{action livestock.toggle option}}>
+      <input class="spec-multiple-choice spec-multiple-choice-{{option.value}}" type="checkbox" checked={{option.isSelected}} onclick={{action option.toggle}}>
       {{option.value}}
     </label>
   {{/each}}


### PR DESCRIPTION
Sometimes a microstate contains an enumeration of related sub-objects
such as with the multiple choice and single choice states, and you want
the actual actions to be located *on* those substates so that the
context of the microstate is implicit.

So, for example, without contextual actions, in order to toggle an
option, you have to generate an action that references both the
choice *and* the option.

```
{{#with (choice) as |choice|}}
  {{#each choice.options as |option|}}
    <button onclick={{action choice.toggle option}}>Toggle</button>
  {{/each}}
{{/with}}
```

But what if instead, we just had to reference only the option and the
choice was implicit.

```
{{#with (choice) as |choice|}}
  {{#each choice.options as |option|}}
    <button onclick={{action option.toggle}}>Toggle</button>
  {{/each}}
{{/with}}
```

In that case, the `toggle` action lives right on the option, and the
`choice` is implicit since every option must by necessity be associated
with a choice. Basically this means there's less things to screw up.