### PR TITLE
state initialization is most flexible of all time

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -5,16 +5,14 @@ const IS_EMBER_1 = Ember.VERSION.split(".").shift() === "1";
 
 export default Ember.Helper.extend({
 
-  default: {},
-
-  initialize(value) {
+  initialize(previous, [value = {}]) {
     return value;
   },
 
-  compute([value = this.default], options) {
+  compute(params, options) {
     this.options = options;
-    if (!this.value || !this._update) {
-      this.value = this.initialize(value, options);
+    if (!this._update) {
+      this.value = this.initialize(this.value, params, options);
     }
     delete this._update;
     let current = this.value;

--- a/addon/helpers/boolean.js
+++ b/addon/helpers/boolean.js
@@ -14,7 +14,10 @@ const False = Object.create([], {
 
 
 export default MicroState.extend({
-  default: false,
+
+  initialize(previous, [value]) {
+    return value != null;
+  },
 
   wrap(value) {
     return !!value ? True : False;

--- a/addon/helpers/choice.js
+++ b/addon/helpers/choice.js
@@ -2,9 +2,7 @@ import { MultipleChoice, SingleChoice } from '../models/choice';
 import { MicroState } from 'ember-microstates';
 
 export default MicroState.extend({
-  default: [],
-  initialize(values, options) {
-    values = values.length >= 0 ? values : [values];
+  initialize(previous, [values = []], options) {
     let Type = !!options.multiple ? MultipleChoice : SingleChoice;
     return Type.create(values, options);
   },

--- a/addon/helpers/list.js
+++ b/addon/helpers/list.js
@@ -1,8 +1,9 @@
 import { MicroState } from 'ember-microstates';
 
 export default MicroState.extend({
-  default: [],
-
+  initialize(current, [array = []]) {
+    return array;
+  },
   actions: {
     add(list, item) {
       return list.concat(item);

--- a/addon/helpers/number.js
+++ b/addon/helpers/number.js
@@ -4,8 +4,6 @@ import assign from '../utils/assign';
 
 export default MicroState.extend({
 
-  default: 0,
-
   wrap: function(value) {
     return assign(new Number(value), {
       toString() { return String(value); }

--- a/addon/helpers/string.js
+++ b/addon/helpers/string.js
@@ -3,7 +3,6 @@ import { MicroState } from 'ember-microstates';
 import assign from '../utils/assign';
 
 export default MicroState.extend({
-  default: "",
 
   wrap(value) {
     return assign(new String(value), {

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -17,7 +17,9 @@ describe('Microstates', function() {
     ];
 
     this.microstate = MicroState.create({
-      default: {initial: 'state'},
+      initialize(current, [state = {initial: 'state'}]) {
+        return state;
+      },
       recompute: onRecompute
     });
 


### PR DESCRIPTION
With the old system of initialization there were two ways to set the
initial state, with the `default` property or with the `initialize`
function. The former allowed you to provide a static value if there was
no value provided, the second allowed you to transform the values passed
into the helper using a function.

This replaces both of these methods with a single, more powerful
initialize() function that takes the *prior* state as its first
argument, the `params` and `options` as passed to the compute function
as the second and third arguments. This allows microstates, should they
choose, to take into account the _prior_ state in their
computation. Most microstates will not need this information, but it
would be necessary for something that wanted to have undo functionality
for example.