### PR TITLE
normalize property descriptors

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import assign from './utils/assign';
-
-const IS_EMBER_1 = Ember.VERSION.split(".").shift() === "1";
+import descriptor from './utils/descriptor';
 
 export default Ember.Helper.extend({
 
@@ -17,37 +16,27 @@ export default Ember.Helper.extend({
     delete this._update;
     let current = this.value;
     let actions = Object.keys(this.actions).reduce((actions, key)=> {
-      actions[key] = {
-        value: (...args)=> {
+      return assign(actions, {
+        [key]: descriptor((...args)=> {
           let action = this.actions[key];
           return this.setState(key, (curr) => action.call(null, curr, ...args));
-        },
-        // If this is Ember < 2, we want to make this property re-configurable
-        // so that it can add a setter when embedded in handlebars. This setter
-        // should never be used, but will keep the handlebars templates from
-        // barking.
-        configurable: IS_EMBER_1 ? true : false
-      };
-      return actions;
+        })
+      });
     }, {});
 
     let collections = Object.keys(this.each).reduce((collections, collectionName)=> {
-      collections[collectionName] = {
-        value: current[collectionName].map((member)=> {
+      return assign(collections, {
+        [collectionName]: descriptor(current[collectionName].map((member)=> {
           return Object.create(member, Object.keys(this.each[collectionName]).reduce((actions, key)=> {
-            actions[key] = {
-              value: (...args)=> {
+            return assign(actions, {
+              [key]: descriptor((...args)=> {
                 let action = this.each[collectionName][key];
                 return this.setState(`${key}-{Ember.String.singularize(collectionName)}`, (curr)=> action.call(null, curr, member, ...args));
-              },
-              configurable: IS_EMBER_1 ? true : false
-            };
-            return actions;
+              })
+            });
           }, {}));
-        }),
-        configurable: IS_EMBER_1 ? true : false
-      };
-      return collections;
+        }))
+      });
     }, {});
     return Object.create(this.wrap(current), assign({}, actions, collections));
   },

--- a/addon/utils/descriptor.js
+++ b/addon/utils/descriptor.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+const IS_EMBER_1 = Ember.VERSION.split(".").shift() === "1";
+
+/**
+ * Takes a single static value and makes a property descriptor that
+ * can be used with `Object.create` or `Object.defineProperty`. E.g.
+ *
+ *   let object = Object.create({}, {
+ *     foo: descriptor('bar'),
+ *     baz: descriptor('bang),
+ *   });
+ *
+ *   object.foo //=> 'bar'
+ *   object.bar //=> 'baz'
+ *
+ * Ember 1.x freeks out if it can't install setters on any object, so
+ * in that case, we actually make the descriptor configurable so it
+ * can be happy and add a setter.
+ *
+ * @param {Object} - the value of the property.
+ * @return {Object} - a property descriptor for this static value
+ */
+export default function descriptor(value) {
+  return {
+    value,
+    // If this is Ember < 2, we want to make this property re-configurable
+    // so that it can add a setter when embedded in handlebars. This setter
+    // should never be used, but will keep the handlebars templates from
+    // barking.
+    configurable: IS_EMBER_1 ? true : false
+  };
+}


### PR DESCRIPTION
The property descriptors were adding a lot of noise to the collecting of
actions for the state objects.

Rather than having to nest each action function in an object, this
introduces the `descriptor` function which creates a read-only property
descriptor for a static value, so we can specify the actions directly.

There is still more extraction to do, but this is a first start.