### PR TITLE
Added Promise support for MicroState transitions

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -53,6 +53,18 @@ export default Ember.Helper.extend({
 
     this._update = true;
     var nextState = updateFn.call(this, this.value);
+
+    if (isThenable(nextState)) {
+      nextState.then((nextState)=>{
+        this.transitionState(eventName, nextState);
+      });
+      return this.value;
+    }
+
+    return this.transitionState(eventName, nextState);
+  },
+
+  transitionState(eventName, nextState) {
     if (nextState !== this.value) {
       this.value = nextState;
       this.recompute();
@@ -62,7 +74,7 @@ export default Ember.Helper.extend({
         sendActionNotification(this, eventName, nextState);
       }
     }
-    return this.value;
+    return nextState;
   },
 
   each: {},
@@ -75,4 +87,8 @@ function sendActionNotification(helper, actionName, state) {
   if (actionCallback && actionCallback.call) {
     actionCallback.call(null, state);
   }
+}
+
+function isThenable(value) {
+  return value && value.then && value.then.call;
 }

--- a/tests/integration/helpers/promise-handler-test.js
+++ b/tests/integration/helpers/promise-handler-test.js
@@ -1,0 +1,73 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+import Ember from 'ember';
+import StringMicrostate from 'ember-microstates/helpers/string';
+
+const {
+  RSVP,
+  run: { later }
+} = Ember;
+
+describeComponent(
+  'promise-handler',
+  'Integration: PromiseHandlerHelper',
+  {
+    integration: true
+  },
+  function() {
+    
+    it('renders', function() {
+
+      this.register('helper:promise-handler', StringMicrostate.extend({
+        initialize() {
+          return 'foo';
+        }
+      }));
+
+      this.render(hbs`{{promise-handler}}`);
+      expect(this.$()).to.have.length(1);
+      expect(this.$().text()).to.equal('foo');
+
+    });
+
+    it('waits for promise to resolve', function(done){
+
+      this.register('helper:promise-handler', StringMicrostate.extend({
+        actions: {
+          refresh() {
+            return new RSVP.Promise(function(resolve){
+              later(function(){ 
+                resolve('bar');
+              }, 50);
+            });
+          }
+        }
+      }));
+
+      this.render(hbs`
+        {{#with (promise-handler 'foo') as |value|}}
+          <span class="value">{{value}}</span>
+          <button {{action value.refresh}}>Refresh</button>
+        {{/with}}
+      `);
+
+      expect(this.$('.value').text()).to.equal('foo');
+
+      this.$('button').click();
+
+      expect(this.$('.value').text()).to.equal('foo');
+
+      later(function(){
+        expect(this.$('.value').text()).to.equal('bar');
+        done();
+      }, 100);
+    });
+
+  }
+);


### PR DESCRIPTION
I added the ability for a MicroState to return a promise from an action. The microstate will wait for promise to resolve before transitioning to the new state. This is a proof of concept, if you agree with this direction then we'd need to provide a way to do error handling. 

I'm thinking actions that return promises would produce values that have some added behaviour, namely `errors` and `isPending`. 

```hbs
{{#with (async-data) as |items|}}

  <button {{action items.fetch}} disabled={{items.isPending}}>Fetch</button>

  {{#each items.errors as |error|}}
   {{error.detail}}
  {{/each}}

  {{#each items as |item|}}
   {{item-component item}}
  {{/each}}

{{/with}}
```

We could also introduce a few custom events that'd allow binding actions when errors occur.

```hbs
{{#with (async-data on-error=(action 'notifyUser') on-resolved=(action 'stopLoading')) as |data|}}
  ...
{{/with}}
```

What do you think?