### PR TITLE
support actions on deeply nested objects

### DIFF
--- a/addon/helpers/choice.js
+++ b/addon/helpers/choice.js
@@ -7,7 +7,7 @@ export default MicroState.extend({
     return Type.create(values, options);
   },
 
-  each: {
+  actions: {
     options: {
       toggle(choice, option) {
         return choice.toggle(option);


### PR DESCRIPTION
This removes the concept of the `each` hash and unifies the decoration of
objects with the `actions` hash. In order to put an action on an object
nested within the state.

If you have the object:

```javascript
{
  topLevel: 'top',
  nested: {
    hello: 'world'
  }
}
```
as your state, and an actions hash that looks like

```javascript
{
  nested: {
    helloPlanet(top, nested) {
      return Object.assign({}, top, {
        nestedProperty: {
          hello: 'planet'
        }
      });
    }
  }
}
```
then all the transition actions inside the nested hash will be
attached to the nested property on the object state. So you would be
able to attach an action:

```handlebars
{{action object.nested.helloPlanet}}
```
If the value of nested is an array, then the `helloPlanet` action will
be attached to every member of the array.

Note that the action function gets passed *both* the state *and* the
nested property. This process is recursive and so you can have nesting in the actions as deep as you care to go.