### PR TITLE
initialization is just another transition action

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -6,15 +6,16 @@ export default Ember.Helper.extend({
 
   compute(params, options) {
     this.options = options;
-
     // collect all of the actions from here up the prototype chain
     let actions = ancestorsOf(this).reduce(function(actions, ancestor) {
-      return assign(actions, ancestor.actions);
+      return ancestor.actions ? assign({}, ancestor.actions, actions) : actions;
     }, {});
 
+    let recompute = actions.recompute;
+    actions.recompute = ()=> recompute.call(null, this.value, params, options);
+
     if (!this._update) {
-      let initial = actions.recompute.call(null, this.value, params, options);
-      this.value = this.transition('recompute', ()=> initial);
+      this.value = this.transition('recompute', actions.recompute);
     }
     delete this._update;
 
@@ -89,6 +90,6 @@ function ancestorsOf(object, ancestors = [object]) {
   if (proto == null) {
     return ancestors;
   } else {
-    return ancestorsOf(proto, [proto].concat(ancestors));
+    return ancestorsOf(proto, ancestors.concat(proto));
   }
 }

--- a/addon/helpers/boolean.js
+++ b/addon/helpers/boolean.js
@@ -15,15 +15,15 @@ const False = Object.create([], {
 
 export default MicroState.extend({
 
-  initialize(previous, [value]) {
-    return value != null;
-  },
-
   wrap(value) {
     return !!value ? True : False;
   },
 
   actions: {
+    recompute(current, [value]) {
+      return !!value;
+    },
+
     toggle(current) {
       return !current;
     },

--- a/addon/helpers/choice.js
+++ b/addon/helpers/choice.js
@@ -2,8 +2,8 @@ import { MultipleChoice, SingleChoice } from '../models/choice';
 import { MicroState } from 'ember-microstates';
 
 export default MicroState.extend({
-  actions: {
 
+  actions: {
     recompute(previous, [values = []], options) {
       let Type = !!options.multiple ? MultipleChoice : SingleChoice;
       return Type.create(values, options);

--- a/addon/helpers/choice.js
+++ b/addon/helpers/choice.js
@@ -2,12 +2,13 @@ import { MultipleChoice, SingleChoice } from '../models/choice';
 import { MicroState } from 'ember-microstates';
 
 export default MicroState.extend({
-  initialize(previous, [values = []], options) {
-    let Type = !!options.multiple ? MultipleChoice : SingleChoice;
-    return Type.create(values, options);
-  },
-
   actions: {
+
+    recompute(previous, [values = []], options) {
+      let Type = !!options.multiple ? MultipleChoice : SingleChoice;
+      return Type.create(values, options);
+    },
+
     options: {
       toggle(choice, option) {
         return choice.toggle(option);

--- a/addon/helpers/list.js
+++ b/addon/helpers/list.js
@@ -1,10 +1,10 @@
 import { MicroState } from 'ember-microstates';
 
 export default MicroState.extend({
-  initialize(current, [array = []]) {
-    return array;
-  },
   actions: {
+    recompute(current, [array = []]) {
+      return array;
+    },
     add(list, item) {
       return list.concat(item);
     },

--- a/addon/helpers/string.js
+++ b/addon/helpers/string.js
@@ -11,6 +11,10 @@ export default MicroState.extend({
   },
 
   actions: {
+    recompute(previous, [string = '']) {
+      return string;
+    },
+
     set(string, value) {
       return String(value);
     }

--- a/tests/integration/helpers/recompute-test.js
+++ b/tests/integration/helpers/recompute-test.js
@@ -1,0 +1,58 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import { describeComponent, it } from 'ember-mocha';
+import { describe, beforeEach } from 'mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+import MicroString from 'ember-microstates/helpers/string';
+
+describeComponent(
+  'recompute-helper',
+  'Integration: Recompute Action',
+  {integration: true},
+  function() {
+    beforeEach(function() {
+      this.register('helper:hello', MicroString.extend({
+        actions: {
+          recompute(current, [value]) {
+            return `Hello ${value}!`;
+          },
+          set(current, value) {
+            return `Hello ${value}!`;
+          }
+        }
+      }));
+
+      this.render(hbs`
+{{#with (hello "World") as |str|}}
+  <span class="message">{{str}}</span>
+
+  <button class="next" {{action (action str.set "Planet")}}>Planet</button>
+  <button class="recompute" {{action (action str.recompute)}}>Reset</button>
+{{/with}}
+`);
+    });
+    it("starts out with a value of Hello World!", function() {
+      expect(this.$('.message').text()).to.equal('Hello World!');
+    });
+
+    describe("clicking on the next button", function() {
+      beforeEach(function() {
+        this.$('.next').click();
+      });
+      it("swaps to Hello Planet", function() {
+        expect(this.$('.message').text()).to.equal('Hello Planet!');
+      });
+      describe("clicking on the recompute button", function() {
+        beforeEach(function() {
+          this.$('.recompute').click();
+        });
+        it("resets it back to its initial state", function() {
+          expect(this.$('.message').text()).to.equal('Hello World!');
+        });
+      });
+
+    });
+
+  }
+);

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -17,10 +17,12 @@ describe('Microstates', function() {
     ];
 
     this.microstate = MicroState.create({
-      initialize(current, [state = {initial: 'state'}]) {
-        return state;
-      },
-      recompute: onRecompute
+      recompute: onRecompute,
+      actions: {
+        recompute(current, [state = {initial: 'state'}]) {
+          return state;
+        }
+      }
     });
 
     Ember.addListener(this.microstate, 'state', this, onStateEvent);
@@ -34,12 +36,12 @@ describe('Microstates', function() {
 
   describe("setting the state without a custom event", function() {
     beforeEach(function() {
-      this.next =  this.microstate.setState(()=> ({average: 'joe'}));
+      this.next =  this.microstate.transition(()=> ({average: 'joe'}));
     });
     it("sets the new state", function() {
       expect(this.microstate.value).to.deep.equal({average: 'joe'});
     });
-    it("returns the new state from the setState() function", function() {
+    it("returns the new state from the transition() function", function() {
       expect(this.next).to.deep.equal({average: 'joe'});
     });
   });
@@ -47,14 +49,14 @@ describe('Microstates', function() {
 
   describe("setting the state with a custom event", function() {
     beforeEach(function() {
-      this.next = this.microstate.setState('custom', ()=> ({totally: 'custom'}));
+      this.next = this.microstate.transition('custom', ()=> ({totally: 'custom'}));
     });
 
     it("sets the new state", function() {
       expect(this.microstate.value).to.deep.equal({totally: 'custom'});
     });
 
-    it("returns the new state from the setState() function", function() {
+    it("returns the new state from the transition() function", function() {
       expect(this.next).to.deep.equal({totally: 'custom'});
     });
 


### PR DESCRIPTION
Resolves #6

This adds the concept of a `recompute` action to all microstates. When a helper is computed because of its inputs, the recompute action is invoked just like any other action.

Note: an interesting side effect of this change is that templates can now bind the `recompute` action, which will have the effect of "resetting" the state to its initial value based on the inputs.

Along with this are several enhancements:

* The `setState` method has been renamed to `transition`
* All action hashes in the entire prototype chain are merged together so that subclasses can inherit actions from their superclass.