### PR TITLE
Allow proper coercion for number values.

### DIFF
--- a/addon/helpers/number.js
+++ b/addon/helpers/number.js
@@ -6,7 +6,8 @@ export default MicroState.extend({
 
   wrap: function(value) {
     return assign(new Number(value), {
-      toString() { return String(value); }
+      toString() { return String(value); },
+      valueOf() { return Number(value); }
     });
   },
 

--- a/tests/integration/helpers/number-test.js
+++ b/tests/integration/helpers/number-test.js
@@ -1,0 +1,39 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import { describeComponent, it } from 'ember-mocha';
+import { describe, beforeEach } from 'mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent(
+  'recompute-helper',
+  'Integration: Number Microstate',
+  {integration: true},
+  function() {
+    beforeEach(function() {
+      this.render(hbs`
+{{#with (number 5) as |num|}}
+{{#with (number 11) as |other|}}
+  <span class="number">{{num}}</span>
+  <span class="other">{{other}}</span>
+
+  <button class="add" {{action (action num.add other)}}>Add</button>
+{{/with}}
+{{/with}}
+`);
+    });
+    it("starts out with a value 5", function() {
+      expect(this.$('.number').text()).to.equal('5');
+      expect(this.$('.other').text()).to.equal('11');
+    });
+
+    describe("clicking on the next button", function() {
+      beforeEach(function() {
+        this.$('.add').click();
+      });
+      it("adds the numbers", function() {
+        expect(this.$('.number').text()).to.equal('16');
+      });
+    });
+
+  }
+);


### PR DESCRIPTION
Because actions can only be added to Objects, we need to use `Number` objects and `String` objects inside the templates. However, when they are coerced into primitives for operations like addittion and subtraction, apparently the `Number.prototype.valueOf()` isn't good enough (I'm not sure why).

This adds a `valueOf()` method to the Number object that wraps the actual number which just coerces it to a primitive number as you would expect.

Fixes #9