### PR TITLE
Object Microstate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-1.13
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-beta
-
+    
 before_install:
   - npm config set spin false
   - npm install -g bower

--- a/addon/helpers/object.js
+++ b/addon/helpers/object.js
@@ -4,6 +4,10 @@ import { reduceObject } from '../utils/object-utils';
 
 export default MicroState.extend({
 
+  prototypeFor(value) {
+    return assign({}, value);
+  },
+
   handlebarsValueFor(object, value) {
     return reduceObject(value, function(result, name, value) {
       return assign(result, {

--- a/addon/helpers/object.js
+++ b/addon/helpers/object.js
@@ -1,0 +1,39 @@
+import { MicroState } from 'ember-microstates';
+import assign from '../utils/assign';
+import { reduceObject } from '../utils/object-utils';
+
+export default MicroState.extend({
+
+  handlebarsValueFor(object, value) {
+    return reduceObject(value, function(result, name, value) {
+      return assign(result, {
+        [name]: value
+      });
+    }, object);
+  },
+
+  actions: {
+    recompute(current, params, options) {
+      return options;
+    },
+    delete(current, target) {
+      return reduceObject(current, function(result, name, value) {
+        if (target === name) {
+          return result;          
+        } else {
+          return assign(result, {
+            [name]: value
+          });
+        }
+      });
+    },
+    assign(current, object={}) {
+      return assign({}, current, object);
+    },
+    put(current, property, value) {
+      return assign({}, current, {
+        [property]: value
+      });
+    }
+  }
+});

--- a/addon/helpers/object.js
+++ b/addon/helpers/object.js
@@ -8,6 +8,13 @@ export default MicroState.extend({
     return assign({}, value);
   },
 
+  /**
+   * Make all of the object properties explicitly enumerable in the template
+   * 
+   * Handlebars helpers like `each-in` use `Object.keys` to iterate object properties. `Object.keys` returns
+   * only properties must be owned by the object. This hook will assign each value's property onto the object,
+   * to ensure that it can be retrieved with `Object.keys`.
+   */
   handlebarsValueFor(object, value) {
     return reduceObject(value, function(result, name, value) {
       return assign(result, {

--- a/addon/helpers/object.js
+++ b/addon/helpers/object.js
@@ -4,10 +4,6 @@ import { reduceObject } from '../utils/object-utils';
 
 export default MicroState.extend({
 
-  prototypeFor(value) {
-    return assign({}, value);
-  },
-
   /**
    * Make all of the object properties explicitly enumerable in the template
    * 
@@ -25,7 +21,7 @@ export default MicroState.extend({
 
   actions: {
     recompute(current, params, options) {
-      return options;
+      return assign({}, options);
     },
     delete(current, target) {
       return reduceObject(current, function(result, name, value) {

--- a/addon/utils/object-utils.js
+++ b/addon/utils/object-utils.js
@@ -1,0 +1,31 @@
+import assign from './assign';
+
+/**
+ * Maps over the keys of an object converting the values of those keys into new
+ * objects. The return value will be an object with the same set of
+ * keys, but a different set of values. E.g.
+ *
+ * > mapObject({first: 1, second: 2}, (value)=> value *2)
+ *
+ *   {first: 2, second: 4}
+ */
+export function mapObject(object, fn) {
+  return reduceObject(object, function(result, name, value) {
+    return assign(result, { [name]: fn(name, value) });
+  });
+}
+
+export function reduceObject(object, fn, result = {}) {
+  eachProperty(object, function(name, value) {
+    result = fn(result, name, value);
+  });
+  return result;
+}
+
+export function eachProperty(object, fn) {
+  if (typeof object === 'object') {
+    Object.keys(object).forEach(function(name) {
+      fn(name, object[name]);
+    });
+  }
+}

--- a/app/helpers/object.js
+++ b/app/helpers/object.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-microstates/helpers/object';

--- a/tests/acceptance/object-test.js
+++ b/tests/acceptance/object-test.js
@@ -1,0 +1,65 @@
+/* jshint expr:true */
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+describe('Acceptance: Object', function() {
+  let application;
+
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    destroyApp(application);
+  });
+
+  beforeEach(function() {
+    return visit('/');
+  });
+
+  it('initializes object', function() {
+    expect($('.spec-object-prop').length).to.equal(3);
+  });
+
+  describe('delete', function() {
+    beforeEach(function() {
+      return click('.spec-object-prop-make .spec-delete-prop');
+    });
+
+    it('removed property with key `make`', function() {
+      expect($('.spec-object-prop').length).to.equal(2);
+      expect($('.spec-object-prop-make').length).to.equal(0);
+    });
+  });
+
+  describe('assign', function() {
+    beforeEach(function() {
+      return click('.spec-object-assign');
+    });
+
+    it('merged object', function() {
+      expect($('.spec-object-prop').length).to.equal(5);
+      expect($('.spec-object-prop-speed .spec-object-prop-value').text()).to.equal('fast');
+      expect($('.spec-object-prop-suspension .spec-object-prop-value').text()).to.equal('stiff');
+    });
+  });
+
+  describe('put', function() {
+    beforeEach(function() {
+      return click('.spec-object-put');
+    });
+
+    it('added property', function() {
+      expect($('.spec-object-prop').length).to.equal(4);
+      expect($('.spec-object-prop-year .spec-object-prop-value').text()).to.equal('1967');
+    });
+  });
+
+});

--- a/tests/dummy/app/helpers/keys.js
+++ b/tests/dummy/app/helpers/keys.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Helper.helper(function([object]) {
+  return Object.keys(object);
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -13,7 +13,7 @@
   value: <span class="spec-boolean-value">{{#if switch}}true{{else}}false{{/if}}</span>
   <hr/>
 
-  <button class="spec-toggle" onclick={{switch.toggle}}>Toggle</button>
+  <button class="spec-toggle" onclick={{action switch.toggle}}>Toggle</button>
   <button class="spec-set-true" onclick={{action switch.set true}}>Set True</button>
   <button class="spec-set-false" onclick={{action switch.set false}}>Set False</button>
 
@@ -25,8 +25,8 @@
   </ol>
   <label>Add Item: {{input enter=(action items.push)}}</label>
   <hr/>
-  <button class="spec-pop" onclick={{items.pop}}>Pop</button>
-  <button class="spec-shift" onclick={{items.shift}}>Shift</button>
+  <button class="spec-pop" onclick={{action items.pop}}>Pop</button>
+  <button class="spec-shift" onclick={{action items.shift}}>Shift</button>
 
   <h3>String</h3>
   {{one-way-input class="spec-string-input" update=str.set}} <span class="spec-string">"{{str}}"</span>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,7 +5,8 @@
    (number 5)
    (choice animals selection="Cow")
    (choice animals selection="Horse" multiple=true)
-   as |switch items str num pets livestock|
+   (object color="red" model="Mustang" make="Ford")
+   as |switch items str num pets livestock car|
 }}
   <h2 id="title">Welcome to Ember</h2>
 
@@ -60,5 +61,13 @@
     {{#each livestock.selection as |selection|}}
       <li> {{selection}}</li>
     {{/each}}
+  </ul>
+  <h3>Object</h3>
+  <ul>
+    {{#each (keys car) as |name|}}
+      <li class="spec-object-prop spec-object-prop-{{name}}"><strong>{{name}}</strong>: <span class="spec-object-prop-value">{{get car name}}</span> <button {{action car.delete name}} class="spec-delete-prop">X</button></li>
+    {{/each}}
+    <button class="spec-object-assign" {{action car.assign (hash speed="fast" suspension="stiff")}}>Add Properties</button>
+    <button class="spec-object-put" {{action car.put "year" 1967}}>Put property</button>
   </ul>
 {{/let}}

--- a/tests/unit/helpers/object-test.js
+++ b/tests/unit/helpers/object-test.js
@@ -1,27 +1,16 @@
 /* jshint expr:true */
-import Ember from 'ember';
 import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import ObjectHelper from 'ember-microstates/helpers/object';
 
 describe('Object', function() {
-  let onState = null;
-  let onToggle = null;
-  let onStateEvent = null;
-  let onToggleEvent = null;
-  let onRecompute = null;
   beforeEach(function() {
-    [onState, onToggle, onStateEvent, onToggleEvent, onRecompute] = [
-      sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()
-    ];
     this.helper = ObjectHelper.create({
-      recompute: onRecompute
+      recompute: sinon.spy()
     });
 
-    Ember.addListener(this.helper, 'state', this, onStateEvent);
-    Ember.addListener(this.helper, 'toggle', this, onToggleEvent);
-    this.value = this.helper.compute([], { hello: 'world' }, {'on-state': onState, 'on-toggle': onToggle});
+    this.value = this.helper.compute([], { hello: 'world' });
     this.valueOf = this.value.valueOf();
   });
 

--- a/tests/unit/helpers/object-test.js
+++ b/tests/unit/helpers/object-test.js
@@ -1,0 +1,43 @@
+/* jshint expr:true */
+import Ember from 'ember';
+import { expect } from 'chai';
+import { describe, beforeEach, it } from 'mocha';
+import sinon from 'sinon';
+import ObjectHelper from 'ember-microstates/helpers/object';
+
+describe('Object', function() {
+  let onState = null;
+  let onToggle = null;
+  let onStateEvent = null;
+  let onToggleEvent = null;
+  let onRecompute = null;
+  beforeEach(function() {
+    [onState, onToggle, onStateEvent, onToggleEvent, onRecompute] = [
+      sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()
+    ];
+    this.helper = ObjectHelper.create({
+      recompute: onRecompute
+    });
+
+    Ember.addListener(this.helper, 'state', this, onStateEvent);
+    Ember.addListener(this.helper, 'toggle', this, onToggleEvent);
+    this.value = this.helper.compute([], { hello: 'world' }, {'on-state': onState, 'on-toggle': onToggle});
+    this.valueOf = this.value.valueOf();
+  });
+
+  it('valueOf returns unboxed value', function() {
+    expect(this.valueOf).to.deep.equal({ hello: 'world' });
+  });
+
+  describe('assign', function() {
+    beforeEach(function() {
+      this.assignedValue = this.value.assign({ hola: 'mundo' });
+      this.assignedValueOf = this.assignedValue.valueOf();
+    });
+
+    it('valueOf returns unboxed value', function() {
+      expect(this.assignedValueOf).to.deep.equal({ hello: 'world', hola: 'mundo' });
+    });
+  });
+
+});


### PR DESCRIPTION
This PR adds Object Microstate that can be created in the template with `(object)` helper. This microstate has the following transitions:

* `assign` - equivalent to calling `Object.assign({}, microstate, attr)` on the microstate
* `delete` - removes property from object
*  `put` - adds property to object

Closes #17 