### PR TITLE
Capitalized helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ each state transition. Forexample, how often have you seen or written
 an action like this?
 
 ```javascript
-actions: { 
-  toggleOpen() { 
-    this.toggleProperty("isOpen"); 
+actions: {
+  toggleOpen() {
+    this.toggleProperty("isOpen");
   }
 }
 ```
@@ -52,10 +52,10 @@ known before hand so that you can simply declare which operations
 correspond to which HTML events.
 
 Using Microstates, we would rewrite the example above using the
-`boolean` helper like so:
+`Boolean` helper like so:
 
 ```handlebars
-{{let isOpen=(boolean)}}
+{{let isOpen=(Boolean)}}
 
 <button onclick={{action isOpen.toggle}}>Toggle</button>
 
@@ -113,12 +113,12 @@ bet is to hit up `#e-microstates` channel in the ember community slack.
 
 ## API
 
-* [`object`](#object)
+* [`Object`](#object)
   + [`assign(attributes)`](#assignattributes)
   + [`delete(key)`](#deletekey)
   + [`put(key,value)`](#putkeyvalue)
   + [`set(value)`](#setvalue)
-* [`list`](#list)
+* [`List`](#list)
   + [`concat(list)`](#concatlist)
   + [`pop`](#pop)
   + [`push(item)`](#pushitem)
@@ -126,11 +126,11 @@ bet is to hit up `#e-microstates` channel in the ember community slack.
   + [`replace(item,other)`](#removeitemother)
   + [`shift`](#shift)
   + [`unshift(item)`](#unshiftitem)
-* [`boolean`](#boolean)
+* [`Boolean`](#boolean)
   + [`toggle`](#toggle)
-* [`string`](#string)
+* [`String`](#string)
   + [`concat(string)`](#concatstring)
-* [`number`](#number)
+* [`Number`](#number)
   + [`add(number)`](#addnumber)
   + [`subtract(number)`](#subtractnumber)
   + [`multiply(number)`](#multiplynumber)
@@ -142,7 +142,7 @@ The object state serves as the base for all other microstates. The
 transitions that are available to object are available to all other types:
 
 ``` handlebars
-{{let car=(object make="Ford" model="Mustang" year=1967)}}
+{{let car=(Object make="Ford" model="Mustang" year=1967)}}
 ```
 
 #### `assign(attributes)`
@@ -175,7 +175,7 @@ Remove a key (and subsequent value) from this object. For example, to delete the
 #### `put(key, value)`
 #### `set(value)`
 
-### `list`
+### `List`
 
 #### `concat(list)`
 #### `pop()`
@@ -185,15 +185,15 @@ Remove a key (and subsequent value) from this object. For example, to delete the
 #### `shift()`
 #### `unshift(item)`
 
-### `boolean`
+### `Boolean`
 
 #### `toggle()`
 
-### `string`
+### `String`
 
 #### `concat(string)`
 
-### `number`
+### `Number`
 
 #### `add(number)`
 #### `subtract(number)`

--- a/addon/initializers/microstates.js
+++ b/addon/initializers/microstates.js
@@ -1,0 +1,20 @@
+import BooleanState from '../helpers/boolean';
+import ChoiceState from '../helpers/choice';
+import ListState from '../helpers/list';
+import NumberState from '../helpers/number';
+import StringState from '../helpers/string';
+import ObjectState from '../helpers/object';
+
+export function initialize(application) {
+  application.register('helper:Boolean', BooleanState);
+  application.register('helper:Choice', ChoiceState);
+  application.register('helper:List', ListState);
+  application.register('helper:Number', NumberState);
+  application.register('helper:String', StringState);   
+  application.register('helper:Object', ObjectState);
+}
+
+export default {
+  name: 'microstates',
+  initialize
+};

--- a/app/helpers/boolean.js
+++ b/app/helpers/boolean.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-microstates/helpers/boolean';

--- a/app/helpers/choice.js
+++ b/app/helpers/choice.js
@@ -1,1 +1,0 @@
-export { default, choice } from 'ember-microstates/helpers/choice';

--- a/app/helpers/list.js
+++ b/app/helpers/list.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-microstates/helpers/list';

--- a/app/helpers/number.js
+++ b/app/helpers/number.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-microstates/helpers/number';

--- a/app/helpers/object.js
+++ b/app/helpers/object.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-microstates/helpers/object';

--- a/app/helpers/string.js
+++ b/app/helpers/string.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-microstates/helpers/string';

--- a/app/initializers/microstates.js
+++ b/app/initializers/microstates.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-microstates/initializers/microstates';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,11 +1,11 @@
 {{#let
-   (boolean)
-   (list groceries)
-   (string "a string")
-   (number 5)
-   (choice animals selection="Cow")
-   (choice animals selection="Horse" multiple=true)
-   (object color="red" model="Mustang" make="Ford")
+   (Boolean)
+   (List groceries)
+   (String "a string")
+   (Number 5)
+   (Choice animals selection="Cow")
+   (Choice animals selection="Horse" multiple=true)
+   (Object color="red" model="Mustang" make="Ford")   
    as |switch items str num pets livestock car|
 }}
   <h2 id="title">Welcome to Ember</h2>

--- a/tests/integration/helpers/number-test.js
+++ b/tests/integration/helpers/number-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import { describe, beforeEach } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
+import Microstates from 'ember-microstates/initializers/microstates';
 
 describeComponent(
   'recompute-helper',
@@ -10,9 +11,10 @@ describeComponent(
   {integration: true},
   function() {
     beforeEach(function() {
+      Microstates.initialize(this.container.registry);      
       this.render(hbs`
-{{#with (number 5) as |num|}}
-{{#with (number 11) as |other|}}
+{{#with (Number 5) as |num|}}
+{{#with (Number 11) as |other|}}
   <span class="number">{{num}}</span>
   <span class="other">{{other}}</span>
 


### PR DESCRIPTION
This PR capitalizes Microstate helpers to allow microstates to be instantiated with the same name as the microstate. For example, `{{let boolean=(Boolean true)}}`

Closes #29 