### PR TITLE
Simpler events

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The object state serves as the base for all other microstates. The
 transitions that are available to object are available to all other types:
 
 ``` handlebars
-{{let car=(Object make="Ford" model="Mustang" year=1967)}}
+{{let car=(Object (hash make="Ford" model="Mustang" year=1967))}}
 ```
 
 #### `assign(attributes)`

--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -61,10 +61,7 @@ export default Ember.Helper.extend({
       this._update = true;
       this.recompute();
       this.sendAction('state', nextState);
-
-      if (eventName) {
-        this.sendAction(eventName, nextState);
-      }
+      this.sendAction(eventName, nextState);
     }
     return nextState;
   },

--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -55,11 +55,6 @@ export default Ember.Helper.extend({
   },
 
   transition(eventName, updateFn = (current)=> current) {
-    if (arguments.length === 1) {
-      updateFn = eventName || (o=> o);
-      eventName = null;
-    }
-
     let nextState = updateFn.call(this, this.value);
     if (nextState !== this.value) {
       this.value = nextState;

--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -86,7 +86,6 @@ export default Ember.Helper.extend({
 
 function sendActionNotification(helper, actionName, state) {
   var actionCallback = helper.options[Ember.String.dasherize(`on-${actionName}`)];
-  Ember.sendEvent(helper, actionName, [state]);
   if (actionCallback && actionCallback.call) {
     actionCallback.call(null, state);
   }

--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -60,13 +60,20 @@ export default Ember.Helper.extend({
       this.value = nextState;
       this._update = true;
       this.recompute();
-      sendActionNotification(this, 'state', nextState);
+      this.sendAction('state', nextState);
 
       if (eventName) {
-        sendActionNotification(this, eventName, nextState);
+        this.sendAction(eventName, nextState);
       }
     }
     return nextState;
+  },
+
+  sendAction(name, state) {
+    var actionCallback = this.options[Ember.String.dasherize(`on-${name}`)];
+    if (actionCallback && actionCallback.call) {
+      actionCallback.call(null, state);
+    }
   },
 
   actions: {
@@ -78,13 +85,6 @@ export default Ember.Helper.extend({
     }
   }
 });
-
-function sendActionNotification(helper, actionName, state) {
-  var actionCallback = helper.options[Ember.String.dasherize(`on-${actionName}`)];
-  if (actionCallback && actionCallback.call) {
-    actionCallback.call(null, state);
-  }
-}
 
 function ancestorsOf(object, ancestors = [object]) {
   let proto = Object.getPrototypeOf(object);

--- a/addon/helpers/object.js
+++ b/addon/helpers/object.js
@@ -20,8 +20,8 @@ export default MicroState.extend({
   },
 
   actions: {
-    recompute(current, params, options) {
-      return assign({}, options);
+    recompute(current, [object = {}]) {
+      return object;
     },
     delete(current, target) {
       return reduceObject(current, function(result, name, value) {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,7 +5,7 @@
    (Number 5)
    (Select animals selection="Cow")
    (Select animals selection="Horse" multiple=true)
-   (Object color="red" model="Mustang" make="Ford")   
+   (Object (hash color="red" model="Mustang" make="Ford"))   
    as |switch items str num pets livestock car|
 }}
   <h2 id="title">Welcome to Ember</h2>

--- a/tests/unit/helpers/boolean-test.js
+++ b/tests/unit/helpers/boolean-test.js
@@ -4,7 +4,7 @@ import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import BooleanHelper from 'ember-microstates/helpers/boolean';
 
-describe('Boolean', function() {
+describe('Unit: Boolean', function() {
   let onState = null;
   let onToggle = null;
   let onRecompute = null;

--- a/tests/unit/helpers/boolean-test.js
+++ b/tests/unit/helpers/boolean-test.js
@@ -10,7 +10,7 @@ describe('Boolean', function() {
   let onRecompute = null;
   beforeEach(function() {
     [onState, onToggle, onRecompute] = [
-      sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()
+      sinon.spy(), sinon.spy(), sinon.spy()
     ];
     this.helper = BooleanHelper.create({
       recompute: onRecompute

--- a/tests/unit/helpers/boolean-test.js
+++ b/tests/unit/helpers/boolean-test.js
@@ -1,5 +1,4 @@
 /* jshint expr:true */
-import Ember from 'ember';
 import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
@@ -8,19 +7,15 @@ import BooleanHelper from 'ember-microstates/helpers/boolean';
 describe('Boolean', function() {
   let onState = null;
   let onToggle = null;
-  let onStateEvent = null;
-  let onToggleEvent = null;
   let onRecompute = null;
   beforeEach(function() {
-    [onState, onToggle, onStateEvent, onToggleEvent, onRecompute] = [
+    [onState, onToggle, onRecompute] = [
       sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()
     ];
     this.helper = BooleanHelper.create({
       recompute: onRecompute
     });
 
-    Ember.addListener(this.helper, 'state', this, onStateEvent);
-    Ember.addListener(this.helper, 'toggle', this, onToggleEvent);
     this.value = this.helper.compute([true], {'on-state': onState, 'on-toggle': onToggle});
     this.valueOf = this.value.valueOf();
   });
@@ -43,16 +38,8 @@ describe('Boolean', function() {
       expect(this.toggled).to.equal(false);
     });
 
-    it("fires the 'state' event", function() {
-      expect(onStateEvent.called).to.equal(true);
-    });
-
     it("invokes the on-state callback", function() {
       expect(onState.calledWith(false)).to.equal(true);
-    });
-
-    it("fires the 'toggle' event", function() {
-      expect(onStateEvent.called).to.equal(true);
     });
 
     it("invokes the on-toggle callback", function() {

--- a/tests/unit/helpers/list-test.js
+++ b/tests/unit/helpers/list-test.js
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import ListHelper from 'ember-microstates/helpers/list';
 
-describe('List', function() {
+describe('Unit: List', function() {
   beforeEach(function() {
     this.helper = ListHelper.create({
       recompute: sinon.spy()

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -10,7 +10,7 @@ describe('Microstates', function() {
   let onRecompute = null;
   beforeEach(function() {
     [onState, onCustom, onRecompute] = [
-      sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()
+      sinon.spy(), sinon.spy(), sinon.spy()
     ];
 
     this.microstate = MicroState.create({

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -29,19 +29,6 @@ describe('Unit: Microstates', function() {
     expect(this.value).to.deep.equal({initial: 'state'});
   });
 
-  describe("setting the state without a custom event", function() {
-    beforeEach(function() {
-      this.next =  this.microstate.transition(()=> ({average: 'joe'}));
-    });
-    it("sets the new state", function() {
-      expect(this.microstate.value).to.deep.equal({average: 'joe'});
-    });
-    it("returns the new state from the transition() function", function() {
-      expect(this.next).to.deep.equal({average: 'joe'});
-    });
-  });
-
-
   describe("setting the state with a custom event", function() {
     beforeEach(function() {
       this.next = this.microstate.transition('custom', ()=> ({totally: 'custom'}));

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -4,7 +4,7 @@ import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import { MicroState } from 'ember-microstates';
 
-describe('Microstates', function() {
+describe('Unit: Microstates', function() {
   let onState = null;
   let onCustom = null;
   let onRecompute = null;

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -1,5 +1,4 @@
 /* jshint expr:true */
-import Ember from 'ember';
 import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
@@ -8,11 +7,9 @@ import { MicroState } from 'ember-microstates';
 describe('Microstates', function() {
   let onState = null;
   let onCustom = null;
-  let onStateEvent = null;
-  let onCustomEvent = null;
   let onRecompute = null;
   beforeEach(function() {
-    [onState, onCustom, onStateEvent, onCustomEvent, onRecompute] = [
+    [onState, onCustom, onRecompute] = [
       sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()
     ];
 
@@ -25,8 +22,6 @@ describe('Microstates', function() {
       }
     });
 
-    Ember.addListener(this.microstate, 'state', this, onStateEvent);
-    Ember.addListener(this.microstate, 'custom', this, onCustomEvent);
     this.value = this.microstate.compute([], {'on-state': onState, 'on-custom': onCustom});
   });
 
@@ -60,16 +55,8 @@ describe('Microstates', function() {
       expect(this.next).to.deep.equal({totally: 'custom'});
     });
 
-    it("fires the 'state' event", function() {
-      expect(onStateEvent.called).to.equal(true);
-    });
-
     it("invokes the on-state callback", function() {
       expect(onState.calledWith({totally: 'custom'})).to.equal(true);
-    });
-
-    it("fires the 'custom' event", function() {
-      expect(onCustomEvent.calledWith({totally: 'custom'})).to.equal(true);
     });
 
     it("invokes the on-custom callback", function() {

--- a/tests/unit/helpers/number-test.js
+++ b/tests/unit/helpers/number-test.js
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import NumberHelper from 'ember-microstates/helpers/number';
 
-describe('Number', function() {
+describe('Unit: Number', function() {
   beforeEach(function() {
     this.helper = NumberHelper.create({
       recompute: sinon.spy()

--- a/tests/unit/helpers/object-test.js
+++ b/tests/unit/helpers/object-test.js
@@ -10,7 +10,7 @@ describe('Object', function() {
       recompute: sinon.spy()
     });
 
-    this.value = this.helper.compute([], { hello: 'world' });
+    this.value = this.helper.compute([{ hello: 'world' }], {});
     this.valueOf = this.value.valueOf();
   });
 

--- a/tests/unit/helpers/object-test.js
+++ b/tests/unit/helpers/object-test.js
@@ -4,13 +4,15 @@ import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import ObjectHelper from 'ember-microstates/helpers/object';
 
-describe('Object', function() {
+describe('Unit: Object', function() {
+  let onAssign;
   beforeEach(function() {
+    onAssign = sinon.spy();
     this.helper = ObjectHelper.create({
       recompute: sinon.spy()
     });
 
-    this.value = this.helper.compute([{ hello: 'world' }], {});
+    this.value = this.helper.compute([{ hello: 'world' }], { "on-assign": onAssign });
     this.valueOf = this.value.valueOf();
   });
 
@@ -22,6 +24,11 @@ describe('Object', function() {
     beforeEach(function() {
       this.assignedValue = this.value.assign({ hola: 'mundo' });
       this.assignedValueOf = this.assignedValue.valueOf();
+    });
+
+    it('invokes the on-assign callback', function() {
+      expect(onAssign.called).to.equal(true);
+      expect(onAssign.calledWith({ hola: 'mundo', hello: 'world' })).to.equal(true);
     });
 
     it('valueOf returns unboxed value', function() {

--- a/tests/unit/helpers/select-test.js
+++ b/tests/unit/helpers/select-test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import SelectHelper from 'ember-microstates/helpers/select';
 import { SingleSelect, MultipleSelect } from 'ember-microstates/models/select';
 
-describe('Select', function() {
+describe('Unit: Select', function() {
   beforeEach(function() {
     this.helper = SelectHelper.create({
       recompute: sinon.spy()

--- a/tests/unit/helpers/string-test.js
+++ b/tests/unit/helpers/string-test.js
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import StringHelper from 'ember-microstates/helpers/string';
 
-describe('String', function() {
+describe('Unit: String', function() {
   beforeEach(function() {
     this.helper = StringHelper.create({
       recompute: sinon.spy()


### PR DESCRIPTION
- Removed Ember event notification
- Refactored `(Object` helper to use `(Microstate value options)` convention
- Added test to check that `on-*` is used for `(Object` helper

Closes #35 