### PR TITLE
Renamed on-state to on-transition

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -60,7 +60,7 @@ export default Ember.Helper.extend({
       this.value = nextState;
       this._update = true;
       this.recompute();
-      this.sendAction('state', nextState);
+      this.sendAction('transition', nextState);
       this.sendAction(eventName, nextState);
     }
     return nextState;

--- a/tests/unit/helpers/boolean-test.js
+++ b/tests/unit/helpers/boolean-test.js
@@ -5,18 +5,18 @@ import sinon from 'sinon';
 import BooleanHelper from 'ember-microstates/helpers/boolean';
 
 describe('Unit: Boolean', function() {
-  let onState = null;
+  let onTransition = null;
   let onToggle = null;
   let onRecompute = null;
   beforeEach(function() {
-    [onState, onToggle, onRecompute] = [
+    [onTransition, onToggle, onRecompute] = [
       sinon.spy(), sinon.spy(), sinon.spy()
     ];
     this.helper = BooleanHelper.create({
       recompute: onRecompute
     });
 
-    this.value = this.helper.compute([true], {'on-state': onState, 'on-toggle': onToggle});
+    this.value = this.helper.compute([true], {'on-transition': onTransition, 'on-toggle': onToggle});
     this.valueOf = this.value.valueOf();
   });
 
@@ -38,8 +38,8 @@ describe('Unit: Boolean', function() {
       expect(this.toggled).to.equal(false);
     });
 
-    it("invokes the on-state callback", function() {
-      expect(onState.calledWith(false)).to.equal(true);
+    it("invokes the on-transition callback", function() {
+      expect(onTransition.calledWith(false)).to.equal(true);
     });
 
     it("invokes the on-toggle callback", function() {

--- a/tests/unit/helpers/microstate-test.js
+++ b/tests/unit/helpers/microstate-test.js
@@ -5,11 +5,11 @@ import sinon from 'sinon';
 import { MicroState } from 'ember-microstates';
 
 describe('Unit: Microstates', function() {
-  let onState = null;
+  let onTransition = null;
   let onCustom = null;
   let onRecompute = null;
   beforeEach(function() {
-    [onState, onCustom, onRecompute] = [
+    [onTransition, onCustom, onRecompute] = [
       sinon.spy(), sinon.spy(), sinon.spy()
     ];
 
@@ -22,7 +22,7 @@ describe('Unit: Microstates', function() {
       }
     });
 
-    this.value = this.microstate.compute([], {'on-state': onState, 'on-custom': onCustom});
+    this.value = this.microstate.compute([], {'on-transition': onTransition, 'on-custom': onCustom});
   });
 
   it("computes to the initial state ", function() {
@@ -42,8 +42,8 @@ describe('Unit: Microstates', function() {
       expect(this.next).to.deep.equal({totally: 'custom'});
     });
 
-    it("invokes the on-state callback", function() {
-      expect(onState.calledWith({totally: 'custom'})).to.equal(true);
+    it("invokes the on-transition callback", function() {
+      expect(onTransition.calledWith({totally: 'custom'})).to.equal(true);
     });
 
     it("invokes the on-custom callback", function() {


### PR DESCRIPTION
This PR renames `on-state` action to `on-transition`.

Closes #51 