### PR TITLE
Refactored actions hash to transitions

### DIFF
--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -6,9 +6,9 @@ export default Ember.Helper.extend({
 
   compute(params, options) {
     this.options = options;
-    // collect all of the actions from here up the prototype chain
-    let actions = ancestorsOf(this).reduce(function(actions, ancestor) {
-      return ancestor.actions ? assign({}, ancestor.actions, actions) : actions;
+    // collect all of the transitions from here up the prototype chain
+    let transitions = ancestorsOf(this).reduce(function(transitions, ancestor) {
+      return ancestor.transitions ? assign({}, ancestor.transitions, transitions) : transitions;
     }, {});
 
     if (!this._update) {
@@ -16,17 +16,17 @@ export default Ember.Helper.extend({
     }
     delete this._update;
 
-    return this.handlebarsValueFor(decorate(this, actions, this.prototypeFor(this.value), [this.value]), this.value);
+    return this.handlebarsValueFor(decorate(this, transitions, this.prototypeFor(this.value), [this.value]), this.value);
 
-    function decorate(microstate, actions, object, context) {
-      return Object.create(object, Object.keys(actions).reduce((values, key)=> {
+    function decorate(microstate, transitions, object, context) {
+      return Object.create(object, Object.keys(transitions).reduce((values, key)=> {
         return assign(values, {
-          [key]: descriptor(valueFor(actions, key))
+          [key]: descriptor(valueFor(transitions, key))
         });
       }, {}));
 
-      function valueFor(actions, key) {
-        let action = actions[key];
+      function valueFor(transitions, key) {
+        let action = transitions[key];
         if (typeof action === 'function') {
           return function(...args) {
             return microstate.transition(key, ()=> action.call(null, ...context, ...args));
@@ -88,7 +88,7 @@ export default Ember.Helper.extend({
     }
   },
 
-  actions: {
+  transitions: {
     set(current, value) {
       return value;
     }

--- a/addon/-microstate.js
+++ b/addon/-microstate.js
@@ -26,17 +26,17 @@ export default Ember.Helper.extend({
       }, {}));
 
       function valueFor(transitions, key) {
-        let action = transitions[key];
-        if (typeof action === 'function') {
+        let transition = transitions[key];
+        if (typeof transition === 'function') {
           return function(...args) {
-            return microstate.transition(key, ()=> action.call(null, ...context, ...args));
+            return microstate.transition(key, ()=> transition.call(null, ...context, ...args));
           };
         } else {
           let next = object[key];
           if (next.map && next.length >=0) {
-            return next.map(val => decorate(microstate, action, val, context.concat(val)));
+            return next.map(val => decorate(microstate, transition, val, context.concat(val)));
           } else {
-            return decorate(microstate, action, next, context.concat(next));
+            return decorate(microstate, transition, next, context.concat(next));
           }
         }
       }

--- a/addon/helpers/boolean.js
+++ b/addon/helpers/boolean.js
@@ -23,7 +23,7 @@ export default MicroState.extend({
     return value ? True : False;
   },
 
-  actions: {
+  transitions: {
     toggle(current) {
       return !current;
     },

--- a/addon/helpers/list.js
+++ b/addon/helpers/list.js
@@ -29,7 +29,7 @@ export default MicroState.extend({
     return wrapped;
   },
 
-  actions: {
+  transitions: {
     add(list, item) {
       return list.concat(item);
     },

--- a/addon/helpers/number.js
+++ b/addon/helpers/number.js
@@ -26,7 +26,7 @@ export default MicroState.extend({
     return wrapped;
   },
 
-  actions: {
+  transitions: {
     add(current, amount) {
       return current + amount;
     },

--- a/addon/helpers/object.js
+++ b/addon/helpers/object.js
@@ -27,7 +27,7 @@ export default MicroState.extend({
     }, object);
   },
 
-  actions: {
+  transitions: {
     delete(current, target) {
       return reduceObject(current, function(result, name, value) {
         if (target === name) {

--- a/addon/helpers/select.js
+++ b/addon/helpers/select.js
@@ -8,7 +8,7 @@ export default MicroState.extend({
     return Type.create(values, options);
   },
 
-  actions: {
+  transitions: {
     options: {
       toggle(selection, option) {
         return selection.toggle(option);


### PR DESCRIPTION
This PR changes the name of the property where transitions are declared for a microstate. Instead of using `actions` which is an Ember convention that describes state mutation, `transitions` are pure functions that receive current value and perform a calculation. The result of the calculation is treated as the new state for the microstate.

Closes #54