### PR TITLE
Use isEqual

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ Boolean represent a `true` or `false` value.
 {{/if}}
 ```
 
+**Note**: In JavaScript, you must use [`Ember.isEqual`](http://emberjs.com/api/#method_isEqual) helper 
+to evaluate equality of this microstate to other values. Read [Equality of Microstates](#aqualityofmicrostates) for more information.
+
 #### `toggle()`
 
 Transition the Boolean microstate to opposite of it's current value.
@@ -345,6 +348,9 @@ Represents a String object.
 {{message}}
 ```
 
+**Note**: In JavaScript, you must use [`Ember.isEqual`](http://emberjs.com/api/#method_isEqual) helper 
+to evaluate equality of this microstate to other values. Read [Equality of Microstates](#aqualityofmicrostates) for more information.
+
 #### `concat(string)`
 
 Add string to the end of the existing value.
@@ -374,6 +380,9 @@ Represents a numerical value.
 
 {{age}}
 ```
+
+**Note**: In JavaScript, you must use [`Ember.isEqual`](http://emberjs.com/api/#method_isEqual) helper 
+to evaluate equality of this microstate to other values. Read [Equality of Microstates](#aqualityofmicrostates) for more information.
 
 #### `increment()`
 
@@ -521,6 +530,79 @@ Make a new selection with this option unselected.
 {{/each}}
 ```
 
+## Equality of Microstates
+
+Microstates are objects that wrap primitive values. Microstates are designed to follow Handlebars equality rules and you 
+can expect tham to work correctly in this environment. For example `{{if (Boolean true) 'yes' 'no'}}` will show `yes` and 
+`{{if (Boolean false) 'yes' 'no'}}` will show `no`. 
+
+In JavaScript, microstates loosely equal(ie `==`) but not strictly equal(ie `===`) to its primitive value. To compare equality 
+of a Microstate in JavaScript, you must use [`Ember.isEqual`](http://emberjs.com/api/#method_isEqual) utility helper.
+
+### Boolean equality
+
+```hbs
+{{let isOpen=(Boolean false)}}
+
+<button {{action 'showModal' isOpen}}>Show Modal</button>
+```
+
+```js
+import Ember from 'ember';
+const { isEqual } from Ember;
+
+export default Ember.Component.extend({
+  actions: {
+    showModal(isOpen) {
+      if (isEqual(isOpen, true)) {
+        // do something positive
+      }
+    }
+  }
+});
+```
+
+### String equality
+
+```hbs
+{{let message=(String 'loren ipsum')}}
+
+{{hide-default message}}
+```
+
+```js
+import Ember from 'ember';
+const { isEqual } from Ember;
+
+export default Ember.Helper.helper(function([str]) {
+  if (isEqual(str, 'loren ipsum')) {
+    return '';
+  } else {
+    return str;
+  }
+});
+```
+
+### Number equality
+
+```hbs
+{{let answer=(Number 42)}}
+
+{{what-question answer}}
+```
+
+```js
+import Ember from 'ember';
+const { isEqual } from Ember;
+
+export default Ember.Helper.helper(function([answer]) {
+  if (isEqual(answer, 42)) {
+    return 'The Almighty Answer to the Meaning of Life, the Universe, and Everything.';
+  } else {
+    return 'What is the question?';
+  }
+});
+```
 
 ## Installation
 

--- a/addon/helpers/boolean.js
+++ b/addon/helpers/boolean.js
@@ -3,13 +3,15 @@ import { MicroState } from 'ember-microstates';
 const True = Object.create([true], {
   value: { value: true },
   valueOf: {value: ()=> { return true; }},
-  toString: {value: ()=> "true" }
+  toString: {value: ()=> "true" },
+  isEqual: { value: (target)=> true === !!target }  
 });
 
 const False = Object.create([], {
   value: { value: false },
   valueOf: { value: ()=> { return false; } },
-  toString: {value: ()=> "false" }
+  toString: { value: ()=> "false" },
+  isEqual: { value: (target)=> false === !!target }
 });
 
 

--- a/addon/helpers/number.js
+++ b/addon/helpers/number.js
@@ -11,7 +11,7 @@ export default MicroState.extend({
     let wrapped = new Number(value);
 
     Object.defineProperties(wrapped, {
-      toString : {
+      toString: {
         value() {
           return String(value);
         }
@@ -19,6 +19,11 @@ export default MicroState.extend({
       valueOf: {
         value() {
           return Number(value);
+        }
+      },
+      isEqual: {
+        value(target) {
+          return value === target;
         }
       }
     });

--- a/addon/helpers/string.js
+++ b/addon/helpers/string.js
@@ -15,7 +15,7 @@ export default MicroState.extend({
     let wrapped = new String(value);
 
     Object.defineProperties(wrapped, {
-      toString : {
+      toString: {
         value() {
           return value;
         }
@@ -23,6 +23,11 @@ export default MicroState.extend({
       valueOf: {
         value() {
           return value;
+        }
+      },
+      isEqual: {
+        value(target) {
+          return value === target;
         }
       }
     });

--- a/tests/unit/helpers/boolean-test.js
+++ b/tests/unit/helpers/boolean-test.js
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import BooleanHelper from 'ember-microstates/helpers/boolean';
+import Ember from 'ember';
+const { isEqual } = Ember;
 
 describe('Unit: Boolean', function() {
   let onTransition = null;
@@ -26,6 +28,10 @@ describe('Unit: Boolean', function() {
 
   it("unboxed to original value", function() {
     expect(this.valueOf).to.equal(true);
+  });
+
+  it('supports Ember.isEqual', function() {
+    expect(isEqual(this.value, true)).to.equal(true);
   });
 
   describe("toggling", function() {

--- a/tests/unit/helpers/number-test.js
+++ b/tests/unit/helpers/number-test.js
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import NumberHelper from 'ember-microstates/helpers/number';
+import Ember from 'ember';
+const { isEqual } = Ember;
 
 describe('Unit: Number', function() {
   beforeEach(function() {
@@ -11,6 +13,10 @@ describe('Unit: Number', function() {
 
     this.value = this.helper.compute([42], {});
     this.valueOf = this.value.valueOf();
+  });
+
+  it('supports Ember.isEqual', function() {
+    expect(isEqual(this.value, 42)).to.equal(true);
   });
 
   describe('initial value', function() {

--- a/tests/unit/helpers/string-test.js
+++ b/tests/unit/helpers/string-test.js
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
 import StringHelper from 'ember-microstates/helpers/string';
+import Ember from 'ember';
+const { isEqual } = Ember;
 
 describe('Unit: String', function() {
   beforeEach(function() {
@@ -46,6 +48,10 @@ describe('Unit: String', function() {
 
   it('unboxed to original value', function() {
     expect(this.valueOf).to.equal('hello world');
+  });
+
+  it('supports Ember.isEqual', function() {
+    expect(isEqual(this.value, 'hello world')).to.equal(true);
   });
 
   describe('set', function() {


### PR DESCRIPTION
This PR adds `isEqual` method to prototype of Boolean, Number and String microstates. 

Related #61 
Closes #62 